### PR TITLE
feat: Implement user login functionality

### DIFF
--- a/mobile-app/src/navigation/AppNavigator.tsx
+++ b/mobile-app/src/navigation/AppNavigator.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
+import LoginScreen from '../screens/LoginScreen';
 import RegistrationScreen from '../screens/RegistrationScreen';
 import MemberDashboard from '../screens/MemberDashboard';
 import AdminDashboard from '../screens/AdminDashboard';
@@ -7,6 +8,7 @@ import AdminDashboard from '../screens/AdminDashboard';
 // Define the types for the route parameters for each screen in the stack.
 // This provides type safety for navigation and route props.
 export type RootStackParamList = {
+  Login: undefined;
   Registration: undefined; // This screen does not receive any parameters.
   MemberDashboard: undefined;
   AdminDashboard: undefined;
@@ -19,7 +21,14 @@ const Stack = createStackNavigator<RootStackParamList>();
 const AppNavigator = () => {
   return (
     // The Stack.Navigator component contains all the screens of the navigator.
-    <Stack.Navigator initialRouteName="Registration">
+    <Stack.Navigator initialRouteName="Login">
+      <Stack.Screen
+        name="Login"
+        component={LoginScreen}
+        options={{
+          title: 'Login', // Set the header title for this screen.
+        }}
+      />
       <Stack.Screen
         name="Registration"
         component={RegistrationScreen}

--- a/mobile-app/src/screens/LoginScreen.tsx
+++ b/mobile-app/src/screens/LoginScreen.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../navigation/AppNavigator';
+import authService from '../services/authService';
+import tokenService from '../services/tokenService';
+
+type LoginScreenNavigationProp = StackNavigationProp<RootStackParamList, 'Login'>;
+
+const LoginScreen = () => {
+  const navigation = useNavigation<LoginScreenNavigationProp>();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogin = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const authResponse = await authService.login({ email, password });
+      await tokenService.saveToken(authResponse.token);
+      navigation.replace(authResponse.user.role === 'admin' ? 'AdminDashboard' : 'MemberDashboard');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'An unknown error occurred.';
+      setError(message);
+      console.error('Login failed:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Login</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        keyboardType="email-address"
+        autoCapitalize="none"
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+      {error && <Text style={styles.errorText}>{error}</Text>}
+      {loading ? (
+        <ActivityIndicator size="large" color="#007bff" />
+      ) : (
+        <>
+          <Button title="Login" onPress={handleLogin} disabled={loading} />
+          <TouchableOpacity onPress={() => navigation.navigate('Registration')}>
+            <Text style={styles.signupText}>Don't have an account? Sign Up</Text>
+          </TouchableOpacity>
+        </>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  signupText: {
+    color: '#007bff',
+    textAlign: 'center',
+    marginTop: 20,
+  },
+  errorText: {
+    color: 'red',
+    textAlign: 'center',
+    marginBottom: 10,
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+    backgroundColor: '#f5f5f5',
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 30,
+  },
+  input: {
+    backgroundColor: '#fff',
+    paddingHorizontal: 15,
+    paddingVertical: 10,
+    borderRadius: 5,
+    marginBottom: 15,
+    borderWidth: 1,
+    borderColor: '#ddd',
+  },
+});
+
+export default LoginScreen;

--- a/mobile-app/src/services/authService.ts
+++ b/mobile-app/src/services/authService.ts
@@ -17,10 +17,15 @@ export interface RegistrationData {
   role: 'member' | 'admin';
 }
 
+export interface LoginData {
+  email: string;
+  password: string;
+}
+
 export interface AuthResponse {
   token: string;
   // You might also get user data back, which you can add here
-  // user: { id: string; name: string; email: string; role: string; }
+  user: { id: string; name: string; email: string; role: 'member' | 'admin' };
 }
 
 const register = async (userData: RegistrationData): Promise<AuthResponse> => {
@@ -37,8 +42,21 @@ const register = async (userData: RegistrationData): Promise<AuthResponse> => {
   }
 };
 
+const login = async (credentials: LoginData): Promise<AuthResponse> => {
+  try {
+    const response = await apiClient.post<AuthResponse>('/auth/login', credentials);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.message || 'Invalid email or password.');
+    }
+    throw new Error('An unexpected error occurred. Please try again.');
+  }
+};
+
 const authService = {
   register,
+  login,
 };
 
 export default authService;


### PR DESCRIPTION
This commit introduces the user login feature as specified in your request.

Key changes include:
- A new `LoginScreen` component with email and password fields.
- An updated `authService` with a `login` function to send credentials to the `/api/auth/login` endpoint.
- Integration of the `LoginScreen` into the main app navigator, making it the initial screen.
- Logic to handle successful login: storing the JWT securely and redirecting you to either the `AdminDashboard` or `MemberDashboard` based on your role.
- Displaying an error message on login failure.
- A navigation link from the `LoginScreen` to the `RegistrationScreen` for new users.

I didn't find an existing test suite, so I didn't run any tests as part of this change.